### PR TITLE
redir in no leaks

### DIFF
--- a/includes/pipex.h
+++ b/includes/pipex.h
@@ -41,6 +41,7 @@ char	*ft_get_absolute_path2(t_data *data, t_cmds *cmds, char *cmd, char **args);
 void	ft_handle_rights2(t_data *data, t_cmds *cmds, char *cmd, char **args, char *tmp2);
 void	ft_free2(t_data *data, t_cmds *cmds, char *cmd, char *error);
 void	ft_handle_pipe_error2(t_cmds *cmds);
+void	ft_handle_file_error2(char *argv, t_cmds *cmds, t_data *data);
 void	ft_handle_fork_error2(t_cmds *cmds);
 void	ft_handle_dup2_error2(t_cmds *cmds);
 void	ft_handle_close_error2(t_cmds *cmds);

--- a/srcs/debug/debug.c
+++ b/srcs/debug/debug.c
@@ -55,6 +55,20 @@ void	print_tab(char **tab)
 	free(tab);
 }
 
+void	print_redir(t_redir *redir)
+{
+	t_redir	*tmp;
+	
+	tmp = redir;
+	while (tmp)
+	{
+		dprintf(2, "redir->type = %d\n", tmp->type);
+		dprintf(2, "redir->path = %s\n", tmp->path);
+		tmp = tmp->next;
+	}
+	
+}
+
 void	print_cmds(t_cmds *cmd_list)
 {
 	t_cmds	*tmp;
@@ -71,10 +85,18 @@ void	print_cmds(t_cmds *cmd_list)
 			dprintf(2, "cmd->args[%d] = %s\n", i, tmp->args[i]);
 			i++;
 		}
+		while (tmp->redir)
+		{
+			dprintf(2, "redir->type = %d\n", tmp->redir->type);
+			dprintf(2, "redir->path = %s\n", tmp->redir->path);
+			free(tmp->redir->path);
+			tmp->redir = tmp->redir->next;
+		}
 		tmp = tmp->next;
 	}
 }
 
+/*
 void	print_redir(t_redir *redir)
 {
 	t_redir	*tmp;
@@ -84,9 +106,7 @@ void	print_redir(t_redir *redir)
 	{
 		dprintf(2, "redir->type = %d\n", tmp->type);
 		dprintf(2, "redir->path = %s\n", tmp->path);
-//		while (tmp->args[i++])
-//			dprintf(2, "redir->args[%d] = %s\n", i, tmp->args[i]);
 		tmp = tmp->next;
 	}
 	
-}
+}*/

--- a/srcs/exec/handle_errors.c
+++ b/srcs/exec/handle_errors.c
@@ -24,6 +24,19 @@ void	ft_handle_file_error(char **argv, t_pipex *pipex)
 	exit (1);
 }
 
+void	ft_handle_file_error2(char *argv, t_cmds *cmds, t_data *data)
+{
+	perror(argv);
+	if (cmds->infile != -1)
+		close(cmds->infile);
+//	if (cmds->outfile != -1)
+//		close(cmds->outfile);
+	ft_waitpid_only_one_cmd(cmds);
+	ft_free_tab(cmds->cmd_path);
+	ft_clean_all(data);
+	exit (1);
+}
+
 void	ft_handle_pipe_error(t_pipex *pipex)
 {
 	ft_putstr_fd("pipe failed\n", 2);
@@ -100,9 +113,10 @@ void	ft_handle_dup2_error2(t_cmds *cmds)
 {
 	ft_putstr_fd("dup2 failed\n", 2);
 	ft_free_tab(cmds->cmd_path);
-/*
+
 	if (cmds->infile != -1 && close(cmds->infile) == -1)
 		ft_putstr_fd("infile close failed\n", 2);
+/*
 	if (cmds->outfile != -1 && close(cmds->outfile) == -1)
 		ft_putstr_fd("outfile close failed\n", 2);
 */

--- a/srcs/exec/handle_processes.c
+++ b/srcs/exec/handle_processes.c
@@ -120,12 +120,26 @@ void	ft_handle_outfile(t_pipex *pipex, char **argv)
 		ft_handle_slash_error(&argv[pipex->argc - 1], pipex);
 }
 
-void     ft_handle_first_cmd(t_cmds *cmds)
+void     ft_handle_first_cmd(t_cmds *cmds) //, t_redir *redir)
 {
         if (!cmds->cmd)
                 return ;
         else
         {
+/*
+		if (cmds->cmd && cmds->redir->type == 4)
+		{
+			cmds->infile = open(cmds->redir->path, O_RDONLY, 0755);
+			if (cmds->infile == - 1)
+			//	ft_handle_file_error2(cmds->cmd, cmds);
+				ft_putstr_fd("infile failed\n", 2);
+			if (dup2(cmds->infile, 1) == -1)
+				ft_handle_dup2_error2(cmds);
+			if (close(cmds->infile) == -1)
+				ft_handle_close_error2(cmds);
+		//	ft_free2(NULL, cmds, cmds->cmd, "je free\n");
+		}
+*/
 		if (close(cmds->prev_pipe[0]) == -1)
 			ft_handle_close_error2(cmds);
 		if (dup2(cmds->curr_pipe[1], 1) == -1)

--- a/srcs/exec/wait_and_close.c
+++ b/srcs/exec/wait_and_close.c
@@ -62,6 +62,11 @@ void	ft_waitpid_only_one_cmd(t_cmds *cmds)
 {
 	int	status;
 
+	if (cmds->redir)
+	{
+		close(cmds->prev_pipe[0]);
+		close(cmds->prev_pipe[1]);
+	}
 	while (errno != ECHILD)
 	{
 		if (cmds->pid == waitpid(-1, &status, 0))

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -81,9 +81,8 @@ int	main(int argc, char **argv, char **env)
 			ft_exec(&data, data.cmd_list, env, data.cmd_list->redir);
 		else if (ft_exit_code(0, GET) == 12)
 			break ;
-		print_tokens(data.token_list);
-		print_cmds(data.cmd_list);
-		print_redir(data.cmd_list->redir);
+//		print_tokens(data.token_list);
+//		print_cmds(data.cmd_list);
 		ft_free_data(&data);
 	}
 	ft_clean_all(&data);


### PR DESCRIPTION
Gestion des redirections d'entrée.
Problème, sur bash `< infile ls` affiche ls, chez nous ça n'affiche rien. Ça la fout mal